### PR TITLE
use unique_ptr and make_unique 

### DIFF
--- a/example_sender/src/ofApp.cpp
+++ b/example_sender/src/ofApp.cpp
@@ -6,22 +6,21 @@ using namespace shmdata;
 //--------------------------------------------------------------
 void ofApp::setup(){
     ofSetFrameRate(30);
-    logger = make_shared<ConsoleLogger>();
+    logger = make_unique<ConsoleLogger>();
     // direct access writer with one reader
-    w = make_shared<Writer>("/tmp/check-shmdata",
+    w = make_unique<Writer>("/tmp/check-shmdata",
          frameSize,
          "video/x-raw, format=(string)RGB, width=(int)" + ofToString(frameWidth) +
          ", height=(int)" + ofToString(frameHeight) +
          ", framerate=(fraction)30/1, pixel-aspect-ratio=(fraction)1/1",
          logger.get());
     assert(*w);
-    r = make_shared<Reader>("/tmp/check-shmdata",
+    r = std::make_unique<Reader>("/tmp/check-shmdata",
          [](void *data, size_t size){
            //auto frame = static_cast<Frame *>(data);
            std::cout << "(direct access) new data for client "
                      //<< frame->count
-                     << " (size " << size << ")"
-                     << std::endl;
+                     << " (size " << size << ")"                      << std::endl;
          },
          nullptr,
          nullptr,

--- a/example_sender/src/ofApp.h
+++ b/example_sender/src/ofApp.h
@@ -28,9 +28,9 @@ public:
 	void dragEvent(ofDragInfo dragInfo);
 	void gotMessage(ofMessage msg);
 
-	shared_ptr<shmdata::ConsoleLogger> logger;
-	shared_ptr<shmdata::Writer> w;
-	shared_ptr<shmdata::Reader> r;
+	unique_ptr<shmdata::ConsoleLogger> logger;
+	unique_ptr<shmdata::Writer> w;
+	unique_ptr<shmdata::Reader> r;
 
 	ofEasyCam cam;
 


### PR DESCRIPTION
because it is error prone to use shared_ptr with shmdatas. But I did not compile the code and I do not know if this compiles/works.

Also, make_unique requires c++14 flag, if you have c++ 11 only, you can replace make_unique allocating you variables like the following:
 r = unique_ptr<Reader>(new Reader(
... reader ctor args ...
));
